### PR TITLE
Fix v2.2 Empty Schedule Bug

### DIFF
--- a/UCLA Radio/UCLA Radio/extensions/DateFormatter+ShowDate.swift
+++ b/UCLA Radio/UCLA Radio/extensions/DateFormatter+ShowDate.swift
@@ -16,10 +16,11 @@ extension DateFormatter {
         case Hour = "ha"
         case HourAndMinute = "h:mma"
     }
-    
+
     // Expect string of DayAndTime DateFormat ("EEE ha")
     func formatShowTimeStringToDateComponents(_ s: String) -> DateComponents? {
         dateFormat = DateFormat.DayAndHour.rawValue
+        locale = Locale(identifier: "en_US")
         if let date = self.date(from: s) {
             var components = Calendar(identifier: .gregorian).dateComponents([.hour, .weekday], from: date)
             components.timeZone = TimeZone(identifier: "America/Los_Angeles")


### PR DESCRIPTION
Fixes a bug we saw in v2.2 🚀 

Some of our users are reporting an empty schedule, where once the data loads for the schedule, nothing is shown in the schedule view controller.

To recreate: switch locale by going to Settings -> General -> Date & Time -> 24-Hour Time (set to YES)

<img width="350" alt="screen shot 2017-02-07 at 9 21 27 pm" src="https://cloud.githubusercontent.com/assets/2042745/23007472/ba4014a2-f3bd-11e6-9f0c-ee4933b7021c.png">
